### PR TITLE
fix: resolve GitHub Actions workflow failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,10 +83,8 @@ jobs:
         if: steps.should-process.outputs.should-process-changesets == 'true'
         run: |
           git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action (Versioning)"
-
-      - name: Run tests before versioning (optional)
-        if: steps.should-process.outputs.should-process-changesets == 'true' && inputs.skip_tests_before_versioning != 'true' && github.event_name == 'workflow_dispatch'
+          git config --local user.name "GitHub Action (Versioning)"      - name: Run tests before versioning (optional)
+        if: steps.should-process.outputs.should-process-changesets == 'true' && inputs.skip_tests_before_versioning != true && github.event_name == 'workflow_dispatch'
         run: npm test # Consider if xvfb is needed here or if tests are robust without it
 
       - name: Process changesets and update version/changelog

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -24,10 +24,10 @@ print_error() {
     echo -e "${RED}❌ $1${NC}"
 }
 
-# Check if we're on dev branch
+# Check if we're on main branch (for automated releases) or dev branch (for manual releases)
 current_branch=$(git rev-parse --abbrev-ref HEAD)
-if [ "$current_branch" != "dev" ]; then
-    print_error "You must be on the 'dev' branch to create a release"
+if [ "$current_branch" != "main" ] && [ "$current_branch" != "dev" ]; then
+    print_error "You must be on the 'main' or 'dev' branch to create a release"
     print_warning "Current branch: $current_branch"
     exit 1
 fi


### PR DESCRIPTION
- Fix branch checking in prepare-release.sh to allow both 'main' and 'dev' branches
- Fix boolean comparison in release.yml for skip_tests_before_versioning parameter
- Fixes #workflow-branch-check-error that was preventing releases on main branch