### PR TITLE
fix: resolve changelog manager merge conflicts and local variable issues

### DIFF
--- a/.changeset/20250527-190646-patch.md
+++ b/.changeset/20250527-190646-patch.md
@@ -1,9 +1,0 @@
----
-type: patch
-description: Fix changelog manager to correctly handle modern YAML frontmatter and version type detection
-date: 2025-05-27
----
-
-# Fix changelog manager to correctly handle modern YAML frontmatter and version type detection
-
-- Fix changelog manager to correctly handle modern YAML frontmatter and version type detection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to the "do-vscode-lm-explorer" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+## [0.8.3] - 2025-05-27
+
+### Fixed
+- Fix changelog manager to correctly handle modern YAML frontmatter and version type detection
 
 ## [0.8.1] - 2025-05-27
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "displayName": "d.o. vscode-lm Explorer",
   "publisher": "doit",
   "description": "Comprehensive VS Code extension that explores and tests Language Model API models with modern accordion UI, complete API documentation, cancellation support, and modular architecture.",
-  "version": "0.8.2",
-
+  "version": "0.8.3",
   "icon": "images/icon.png",
   "engines": {
     "vscode": "^1.90.0"

--- a/scripts/changelog-manager.sh
+++ b/scripts/changelog-manager.sh
@@ -615,9 +615,6 @@ process_ci_release() {
                 if grep -q "^---$" "$changeset_file"; then
                     # Extract from YAML frontmatter format - look for package name with version type
                     local yaml_content=$(sed -n '/^---$/,/^---$/p' "$changeset_file")
-<<<<<<< Updated upstream
-                    if echo "$yaml_content" | grep -q ': major'; then
-=======
                     # Look for package-scoped version declarations first
                     if echo "$yaml_content" | grep -q '"do-vscode-lm-explorer": major\|"do-vscode-lm-explorer": "major"'; then
                         type="breaking"
@@ -627,7 +624,6 @@ process_ci_release() {
                         type="fix"
                     # Fallback to generic type declarations
                     elif echo "$yaml_content" | grep -q ': major'; then
->>>>>>> Stashed changes
                         type="breaking"
                     elif echo "$yaml_content" | grep -q ': minor'; then
                         type="feature"
@@ -872,19 +868,19 @@ case "$COMMAND" in
                 echo -e "${CYAN}Auto-detecting change type from changesets...${NC}"
                 
                 # Check changesets for breaking changes or features first
-                local has_breaking=false
-                local has_features=false
-                local has_patches=false
+                has_breaking=false
+                has_features=false
+                has_patches=false
                 
                 if [ -d "$CHANGESET_DIR" ]; then
                     for changeset_file in "$CHANGESET_DIR"/*.md; do
                         if [ -f "$changeset_file" ] && [ "$(basename "$changeset_file")" != "README.md" ]; then
-                            local type=""
+                            type=""
                             
                             # Check if it's new YAML frontmatter format
                             if grep -q "^---$" "$changeset_file"; then
                                 # Extract from YAML frontmatter format - look for package name with version type
-                                local yaml_content=$(sed -n '/^---$/,/^---$/p' "$changeset_file")
+                                yaml_content=$(sed -n '/^---$/,/^---$/p' "$changeset_file")
                                 if echo "$yaml_content" | grep -q ': major'; then
                                     type="breaking"
                                 elif echo "$yaml_content" | grep -q ': minor'; then


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
The changelog manager script had critical issues preventing successful execution:
- Git merge conflict markers were left unresolved, causing syntax errors
- Local variable declarations were used outside of function scope, causing bash errors

### Solution
- ✅ **Fixed merge conflict markers**: Resolved Git merge conflict markers in scripts/changelog-manager.sh
- ✅ **Removed improper local declarations**: Fixed local variable usage outside function scope
- ✅ **Updated version**: Successfully processed changeset and updated to version 0.8.3
- ✅ **Updated changelog**: Added entry for the changelog manager fix
- ✅ **Cleaned up**: Removed processed changeset files

### Changes Made
- **scripts/changelog-manager.sh**: Fixed merge conflicts and local variable scope issues
- **CHANGELOG.md**: Added entry for version 0.8.3 with changelog manager fix
- **package.json**: Bumped version from 0.8.2 to 0.8.3
- **Removed**: .changeset/20250527-190646-patch.md (processed changeset)

### Testing
- ✅ Script now runs successfully without syntax errors
- ✅ Changeset processing works correctly
- ✅ Version bumping and changelog generation functional

### Impact
- 🔧 **Fixes broken CI/CD**: Resolves changelog management system failures
- 🚀 **Enables automated releases**: Changeset system now fully operational
- 📝 **Improves release process**: Proper version management restored

This fix is critical for the automated release pipeline and ensures the changeset management system works correctly for future releases.