### PR TITLE
Potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: write
+  packages: write
+  pull-requests: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/d-oit/do-vscode-lm-api-explorer/security/code-scanning/16](https://github.com/d-oit/do-vscode-lm-api-explorer/security/code-scanning/16)

To fix this problem, we need to add a `permissions` block to the workflow. This block will explicitly specify the minimal permissions required for the workflow to function properly. Based on the workflow's operations, such as checking out the repository, modifying version files, committing changes, creating tags, and managing releases, the following permissions are required:
- `contents: write` for pushing changes and creating tags.
- `packages: write` for uploading the VSIX package.
- `pull-requests: write` for any potential pull request updates during the release process.

The `permissions` block should be added at the root level of the workflow to apply permissions uniformly to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
